### PR TITLE
Rename getAssetResources to listAssetResources

### DIFF
--- a/src/api/assets.ts
+++ b/src/api/assets.ts
@@ -53,7 +53,7 @@ async function createAssetResource(
  * @param {GotClient} client API client
  * @returns {Promise<AssetApiResource[]>}
  */
-async function listAssetResources(serviceSid: string, client: GotClient) {
+export async function listAssetResources(serviceSid: string, client: GotClient) {
   try {
     const resp = await client.get(`/Services/${serviceSid}/Assets`);
     const content = (resp.body as unknown) as AssetList;

--- a/src/api/assets.ts
+++ b/src/api/assets.ts
@@ -53,7 +53,7 @@ async function createAssetResource(
  * @param {GotClient} client API client
  * @returns {Promise<AssetApiResource[]>}
  */
-async function getAssetResources(serviceSid: string, client: GotClient) {
+async function listAssetResources(serviceSid: string, client: GotClient) {
   try {
     const resp = await client.get(`/Services/${serviceSid}/Assets`);
     const content = (resp.body as unknown) as AssetList;
@@ -78,7 +78,7 @@ export async function getOrCreateAssetResources(
   client: GotClient
 ): Promise<AssetResource[]> {
   const output: AssetResource[] = [];
-  const existingAssets = await getAssetResources(serviceSid, client);
+  const existingAssets = await listAssetResources(serviceSid, client);
   const assetsToCreate: RawAssetWithPath[] = [];
 
   assets.forEach(asset => {


### PR DESCRIPTION
Looking at the implementation of the function endpoints i was expecting the function for asset handling to be `listAssetResources` (the `listFunctionResources` counterpart). I think a renaming before this goes public can be beneficial for consistency. :) 

Haha yeah – and I'd need this one publicly exposed too. 🙈 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [s] I acknowledge that all my contributions will be made under the project's license.
