### PR TITLE
fix(client): fix client service error information

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -332,10 +332,10 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
             `Service with name "${config.serviceName}" already exists with SID "${alternativeServiceSid}".`
           );
           error.name = 'conflicting-servicename';
-          Object.defineProperty(err, 'serviceSid', {
+          Object.defineProperty(error, 'serviceSid', {
             value: alternativeServiceSid,
           });
-          Object.defineProperty(err, 'serviceName', {
+          Object.defineProperty(error, 'serviceName', {
             value: config.serviceName,
           });
           throw error;


### PR DESCRIPTION
I ran into this error and it's great that `serviceSid` and `serviceName` will be available in th error object. Unfortunately, it was the wrong error object. :) 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
