### PR TITLE
feat(logs): implements fetch and list of logs

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,3 +7,4 @@ export * from './environments';
 export * from './functions';
 export * from './services';
 export * from './variables';
+export * from './logs';

--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -1,0 +1,57 @@
+/** @module @twilio-labs/serverless-api/dist/api */
+
+import debug from 'debug';
+import { GotClient, LogApiResource, LogList, Sid } from '../types';
+
+const log = debug('twilio-serverless-api:logs');
+
+/**
+ * Calls the API to retrieve a list of all assets
+ *
+ * @param {Sid} environmentSid environment in which to get logs
+ * @param {Sid} serviceSid service to look for logs
+ * @param {GotClient} client API client
+ * @returns {Promise<LogApiResource[]>}
+ */
+export async function listLogResources(
+  environmentSid: Sid,
+  serviceSid: Sid,
+  client: GotClient
+) {
+  try {
+    const resp = await client.get(
+      `/Services/${serviceSid}/Environments/${environmentSid}/Logs`
+    );
+    const content = (resp.body as unknown) as LogList;
+    return content.logs;
+  } catch (err) {
+    log('%O', err);
+    throw err;
+  }
+}
+
+/**
+ * Calls the API to retrieve a list of all assets
+ *
+ * @param {Sid} logSid SID of log to retrieve
+ * @param {Sid} environmentSid environment in which to get logs
+ * @param {Sid} serviceSid service to look for logs
+ * @param {GotClient} client API client
+ * @returns {Promise<LogApiResource>}
+ */
+export async function getLog(
+  logSid: Sid,
+  environmentSid: Sid,
+  serviceSid: Sid,
+  client: GotClient
+) {
+  try {
+    const resp = await client.get(
+      `/Services/${serviceSid}/Environments/${environmentSid}/Logs/${logSid}`
+    );
+    return (resp.body as unknown) as LogApiResource;
+  } catch (err) {
+    log('%O', err);
+    throw err;
+  }
+}

--- a/src/api/services.ts
+++ b/src/api/services.ts
@@ -1,7 +1,7 @@
 /** @module @twilio-labs/serverless-api/dist/api */
 
 import debug from 'debug';
-import { GotClient, ServiceList, ServiceResource } from '../types';
+import { GotClient, ServiceList, ServiceResource, Sid } from '../types';
 
 const log = debug('twilio-serverless-api:services');
 
@@ -74,4 +74,17 @@ export async function findServiceSid(
     throw err;
   }
   return undefined;
+}
+
+export async function getService(
+  sid: Sid,
+  client: GotClient
+): Promise<ServiceResource> {
+  try {
+    const resp = await client.get(`/Services/${sid}`);
+    return (resp.body as unknown) as ServiceResource;
+  } catch (err) {
+    log('%O', err);
+    throw err;
+  }
 }

--- a/src/types/serverless-api.ts
+++ b/src/types/serverless-api.ts
@@ -8,11 +8,14 @@ export interface ResourceBase {
   sid: Sid;
   account_sid: Sid;
   date_created: string;
-  date_updated: string;
   url: string;
 }
 
-export interface FunctionApiResource extends ResourceBase {
+export interface UpdateableResourceBase extends ResourceBase {
+  date_updated: string;
+}
+
+export interface FunctionApiResource extends UpdateableResourceBase {
   friendly_name: string;
 }
 
@@ -20,7 +23,7 @@ export interface FunctionList {
   functions: FunctionApiResource[];
 }
 
-export interface AssetApiResource extends ResourceBase {
+export interface AssetApiResource extends UpdateableResourceBase {
   friendly_name: string;
 }
 
@@ -28,7 +31,7 @@ export interface AssetList {
   assets: AssetApiResource[];
 }
 
-export interface ServiceResource extends ResourceBase {
+export interface ServiceResource extends UpdateableResourceBase {
   unique_name: string;
 }
 
@@ -36,7 +39,7 @@ export interface ServiceList {
   services: ServiceResource[];
 }
 
-export interface EnvironmentResource extends ResourceBase {
+export interface EnvironmentResource extends UpdateableResourceBase {
   unique_name: string;
   domain_name: string;
   build_sid: string;
@@ -47,7 +50,7 @@ export interface EnvironmentList {
   environments: EnvironmentResource[];
 }
 
-export interface VersionResource extends ResourceBase {
+export interface VersionResource extends UpdateableResourceBase {
   pre_signed_upload_url: {
     url: string;
     kmsARN: string;
@@ -56,12 +59,10 @@ export interface VersionResource extends ResourceBase {
 
 export type BuildStatus = 'building' | 'completed' | 'failed';
 
-export interface VersionOnBuild extends ResourceBase {
+export interface VersionOnBuild extends UpdateableResourceBase {
   path: string;
   visibility: 'public' | 'protected' | 'private';
-  date_created: string;
   service_sid: string;
-  account_sid: string;
 }
 
 export interface FunctionVersion extends VersionOnBuild {
@@ -72,7 +73,7 @@ export interface AssetVersion extends VersionOnBuild {
   asset_sid: string;
 }
 
-export interface BuildResource extends ResourceBase {
+export interface BuildResource extends UpdateableResourceBase {
   status: BuildStatus;
   function_versions: FunctionVersion[];
   asset_versions: AssetVersion[];
@@ -82,15 +83,10 @@ export interface BuildList {
   builds: BuildResource[];
 }
 
-export interface VariableResource extends ResourceBase {
-  date_updated: string;
+export interface VariableResource extends UpdateableResourceBase {
   environment_sid: string;
   value: string;
-  account_sid: string;
-  url: string;
   key: string;
-  sid: string;
-  date_created: string;
   service_sid: string;
 }
 
@@ -103,3 +99,17 @@ export type BuildConfig = {
   functionVersions?: Sid[];
   assetVersions?: Sid[];
 };
+
+export interface LogApiResource extends ResourceBase {
+  service_sid: string;
+  environment_sid: string;
+  deployment_sid: string;
+  function_sid: string;
+  request_sid: string;
+  level: string;
+  message: string;
+}
+
+export interface LogList {
+  logs: LogApiResource[];
+}


### PR DESCRIPTION
This also consolidates some of the API return types to reduce duplication. It also implements the missing `getService` API method to fetch an individual service object.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
