### PR TITLE
fix(environments): fix deploying to production

### DIFF
--- a/src/api/environments.ts
+++ b/src/api/environments.ts
@@ -66,7 +66,7 @@ export async function createEnvironmentFromSuffix(
     form: true,
     body: {
       UniqueName: uniqueName,
-      DomainSuffix: domainSuffix,
+      DomainSuffix: domainSuffix || undefined,
       // this property currently doesn't exist but for the future lets set it
       FriendlyName: `${uniqueName} Environment (Created by CLI)`,
     },
@@ -105,7 +105,9 @@ export async function getEnvironmentFromSuffix(
 ): Promise<EnvironmentResource> {
   const environments = await listEnvironments(serviceSid, client);
   let foundEnvironments = environments.filter(
-    e => e.domain_suffix === domainSuffix
+    e =>
+      e.domain_suffix === domainSuffix ||
+      (domainSuffix.length === 0 && e.domain_suffix === null)
   );
 
   let env: EnvironmentResource | undefined;

--- a/src/client.ts
+++ b/src/client.ts
@@ -347,8 +347,9 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
 
     this.emit('status-update', {
       status: DeployStatus.CONFIGURING_ENVIRONMENT,
-      message: `Configuring "${config.functionsEnv ||
-        'production'}" environment`,
+      message: `Configuring ${
+        config.functionsEnv.length === 0 ? 'bare' : `"${config.functionsEnv}"`
+      } environment`,
     });
     const environment = await createEnvironmentIfNotExists(
       config.functionsEnv,

--- a/src/client.ts
+++ b/src/client.ts
@@ -347,7 +347,8 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
 
     this.emit('status-update', {
       status: DeployStatus.CONFIGURING_ENVIRONMENT,
-      message: `Configuring "${config.functionsEnv}" environment`,
+      message: `Configuring "${config.functionsEnv ||
+        'production'}" environment`,
     });
     const environment = await createEnvironmentIfNotExists(
       config.functionsEnv,


### PR DESCRIPTION
When no domain suffix is set we should deploy to production. Similarly we should handle the lookup
of the right environment which was broken til now

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
