### PR TITLE
(absolute) link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const utils = require('@twilio-labs/serverless-api/dist/utils');
 
 ## Contributing
 
-This project welcomes contributions from the community. Please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file for more details.
+This project welcomes contributions from the community. Please see the [`CONTRIBUTING.md`](https://github.com/twilio-labs/serverless-api/blob/master/CONTRIBUTING.md) file for more details.
 
 ### Code of Conduct
 


### PR DESCRIPTION
link to contributing.md changed to absolute 

Reason for this - is website https://serverless-api.twilio-labs.com/  that generated by this readme
doesn't actually have CONTRIBUTING.md

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
