### PR TITLE
feat(logs): add logs fetching and streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "jest": "jest",
     "test": "run-s build:noemit jest",
     "build": "tsc",
+    "watch": "tsc --watch",
     "build:noemit": "tsc --noEmit",
     "postbuild": "npm shrinkwrap",
     "docs": "typedoc --options typedoc.json",
@@ -16,7 +17,7 @@
     "lint-staged": "lint-staged",
     "cm": "git-cz",
     "release": "HUSKY_SKIP_HOOKS=1 standard-version",
-    "reset-dependencies": "bash ./hooks/update-dependencies"
+    "reset-dependencies": "bash ./hooks/update-dependencies.sh"
   },
   "publishConfig": {
     "access": "public"

--- a/src/api/functions.ts
+++ b/src/api/functions.ts
@@ -180,3 +180,14 @@ export async function uploadFunction(
   const version = await createFunctionVersion(fn, serviceSid, client);
   return version.sid;
 }
+
+/**
+ * Checks if a string is an function SID by checking its prefix and length
+ *
+ * @export
+ * @param {string} str the string to check
+ * @returns
+ */
+export function isFunctionSid(str: string) {
+  return str.startsWith('ZH') && str.length === 34;
+}

--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -33,6 +33,31 @@ export async function listLogResources(
 /**
  * Calls the API to retrieve a list of all assets
  *
+ * @param {Sid} environmentSid environment in which to get logs
+ * @param {Sid} serviceSid service to look for logs
+ * @param {GotClient} client API client
+ * @returns {Promise<LogApiResource[]>}
+ */
+export async function listOnePageLogResources(
+  environmentSid: Sid,
+  serviceSid: Sid,
+  client: GotClient
+) {
+  try {
+    const resp = await client.get(
+      `/Services/${serviceSid}/Environments/${environmentSid}/Logs`
+    );
+    const content = (resp.body as unknown) as LogList;
+    return content.logs;
+  } catch (err) {
+    log('%O', err);
+    throw err;
+  }
+}
+
+/**
+ * Calls the API to retrieve a list of all assets
+ *
  * @param {Sid} logSid SID of log to retrieve
  * @param {Sid} environmentSid environment in which to get logs
  * @param {Sid} serviceSid service to look for logs

--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -43,15 +43,30 @@ export async function listOnePageLogResources(
   serviceSid: Sid,
   client: GotClient,
   pageSize: number = 50,
-  filterByFunctionSid?: string
+  functionSid?: string,
+  startDate?: string | Date,
+  endDate?: string | Date,
+  pageToken?: string
 ) {
   try {
-    const functionFilter = filterByFunctionSid
-      ? `&FunctionSid=${filterByFunctionSid}`
-      : '';
-    const resp = await client.get(
-      `/Services/${serviceSid}/Environments/${environmentSid}/Logs?PageSize=${pageSize}${functionFilter}`
-    );
+    let url = `/Services/${serviceSid}/Environments/${environmentSid}/Logs?PageSize=${pageSize}`;
+    if (typeof functionSid !== 'undefined') {
+      url += `&FunctionSid=${functionSid}`;
+    }
+    if (typeof startDate !== 'undefined') {
+      url += `&StartDate=${
+        startDate instanceof Date ? startDate.toISOString() : startDate
+      }`;
+    }
+    if (typeof endDate !== 'undefined') {
+      url += `&EndDate=${
+        endDate instanceof Date ? endDate.toISOString() : endDate
+      }`;
+    }
+    if (typeof pageToken !== 'undefined') {
+      url += `&PageToken=${pageToken}`;
+    }
+    const resp = await client.get(url);
     const content = (resp.body as unknown) as LogList;
     return content.logs;
   } catch (err) {

--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -1,7 +1,7 @@
 /** @module @twilio-labs/serverless-api/dist/api */
 
 import debug from 'debug';
-import { GotClient, LogApiResource, LogList, Sid } from '../types';
+import { GotClient, LogApiResource, LogList, Sid, LogFilters } from '../types';
 import { getPaginatedResource } from './utils/pagination';
 
 const log = debug('twilio-serverless-api:logs');
@@ -42,12 +42,10 @@ export async function listOnePageLogResources(
   environmentSid: Sid,
   serviceSid: Sid,
   client: GotClient,
-  pageSize: number = 50,
-  functionSid?: string,
-  startDate?: string | Date,
-  endDate?: string | Date,
-  pageToken?: string
+  filters: LogFilters
 ): Promise<LogApiResource[]> {
+  const pageSize = filters.pageSize || 50;
+  const { functionSid, startDate, endDate, pageToken } = filters;
   try {
     let url = `/Services/${serviceSid}/Environments/${environmentSid}/Logs?PageSize=${pageSize}`;
     if (typeof functionSid !== 'undefined') {

--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -41,11 +41,16 @@ export async function listLogResources(
 export async function listOnePageLogResources(
   environmentSid: Sid,
   serviceSid: Sid,
-  client: GotClient
+  client: GotClient,
+  pageSize: number = 50,
+  filterByFunctionSid?: string
 ) {
   try {
+    const functionFilter = filterByFunctionSid
+      ? `&FunctionSid=${filterByFunctionSid}`
+      : '';
     const resp = await client.get(
-      `/Services/${serviceSid}/Environments/${environmentSid}/Logs`
+      `/Services/${serviceSid}/Environments/${environmentSid}/Logs?PageSize=${pageSize}${functionFilter}`
     );
     const content = (resp.body as unknown) as LogList;
     return content.logs;

--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -47,7 +47,7 @@ export async function listOnePageLogResources(
   startDate?: string | Date,
   endDate?: string | Date,
   pageToken?: string
-) {
+): Promise<LogApiResource[]> {
   try {
     let url = `/Services/${serviceSid}/Environments/${environmentSid}/Logs?PageSize=${pageSize}`;
     if (typeof functionSid !== 'undefined') {
@@ -68,7 +68,7 @@ export async function listOnePageLogResources(
     }
     const resp = await client.get(url);
     const content = (resp.body as unknown) as LogList;
-    return content.logs;
+    return content.logs as LogApiResource[];
   } catch (err) {
     log('%O', err);
     throw err;

--- a/src/client.ts
+++ b/src/client.ts
@@ -228,8 +228,12 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
       }
       filterByFunction = foundFunction.sid;
     }
-
-    const logsStream = new LogsStream(environment, serviceSid, logsConfig);
+    const logsStream = new LogsStream(
+      environment,
+      serviceSid,
+      this.client,
+      logsConfig
+    );
 
     return logsStream;
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -43,10 +43,10 @@ import {
   ListConfig,
   ListResult,
   LogApiResource,
+  LogsConfig,
 } from './types';
 import { DeployStatus } from './types/consts';
 import { getListOfFunctionsAndAssets, SearchConfig } from './utils/fs';
-import { LogsConfig } from './types/logs';
 import { LogsStream } from './streams/logs';
 import { listOnePageLogResources } from './api/logs';
 
@@ -266,13 +266,10 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
     }
 
     try {
-      return listOnePageLogResources(
-        environment,
-        serviceSid,
-        this.client,
-        50,
-        filterByFunction
-      );
+      return listOnePageLogResources(environment, serviceSid, this.client, {
+        pageSize: 50,
+        functionSid: filterByFunction,
+      });
     } catch (e) {
       throw e;
     }

--- a/src/streams/logs.ts
+++ b/src/streams/logs.ts
@@ -27,8 +27,10 @@ export class LogsStream extends Readable {
         this.environmentSid,
         this.serviceSid,
         this.client,
-        this.config.limit,
-        this.config.filterByFunction
+        {
+          functionSid: this.config.filterByFunction,
+          pageSize: this.config.limit,
+        }
       );
       logs
         .filter(log => !this._viewedSids.has(log.sid))

--- a/src/streams/logs.ts
+++ b/src/streams/logs.ts
@@ -5,7 +5,6 @@ import { LogsConfig } from '../types/logs';
 
 export class LogsStream extends Readable {
   private _pollingFrequency: number;
-  private _buffer: Array<LogApiResource>;
   private _interval: NodeJS.Timeout | undefined;
   private _viewedSids: Set<Sid>;
 
@@ -16,7 +15,6 @@ export class LogsStream extends Readable {
     private config: LogsConfig
   ) {
     super({ objectMode: true });
-    this._buffer = [];
     this._interval = undefined;
     this._viewedSids = new Set();
     this._pollingFrequency = config.pollingFrequency || 1000;

--- a/src/streams/logs.ts
+++ b/src/streams/logs.ts
@@ -1,0 +1,58 @@
+import { Readable } from 'stream';
+import { listOnePageLogResources } from '../api/logs';
+import { LogApiResource, Sid, GotClient } from '../types';
+import { ClientConfig } from '../types/client';
+import { createGotClient } from '../client';
+
+export class LogStream extends Readable {
+  _buffer: Array<LogApiResource>;
+  _interval: NodeJS.Timeout | undefined;
+  client: GotClient;
+  pollingFrequency = 1000;
+  _viewedSids: Set<Sid>;
+
+  constructor(
+    private environmentSid: Sid,
+    private serviceSid: Sid,
+    clientConfig: ClientConfig
+  ) {
+    super({ objectMode: true });
+    this._buffer = [];
+    this._interval = undefined;
+    this._viewedSids = new Set();
+    this.client = createGotClient(clientConfig);
+  }
+
+  async _poll() {
+    try {
+      const logs = await listOnePageLogResources(
+        this.environmentSid,
+        this.serviceSid,
+        this.client
+      );
+      logs
+        .filter(log => !this._viewedSids.has(log.sid))
+        .forEach(log => {
+          this._viewedSids.add(log.sid);
+          this.push(JSON.stringify(log));
+        });
+    } catch (err) {
+      this.destroy(err);
+    }
+  }
+
+  _read() {
+    if (!this._interval) {
+      this._interval = setInterval(() => {
+        this._poll();
+      }, this.pollingFrequency);
+    }
+  }
+
+  _destroy() {
+    if (this._interval) {
+      clearInterval(this._interval);
+      this._interval = undefined;
+    }
+  }
+}

--- a/src/streams/logs.ts
+++ b/src/streams/logs.ts
@@ -47,7 +47,7 @@ export class LogsStream extends Readable {
         .filter(log => !this._viewedSids.has(log.sid))
         .reverse()
         .forEach(log => {
-          this.push(JSON.stringify(log));
+          this.push(log);
         });
       // Replace the set each time rather than adding to the set.
       // This way the set is always the size of a page of logs and the next page

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './deploy';
 export * from './generic';
 export * from './list';
 export * from './serverless-api';
+export * from './logs';

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -8,6 +8,7 @@ export type LogsConfig = {
   tail: boolean;
   limit?: number;
   filterByFunction?: string | Sid;
+  pollingFrequency?: number;
 };
 
 export type LogFilters = {

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -1,0 +1,12 @@
+/** @module @twilio-labs/serverless-api */
+
+import { ClientConfig } from './client';
+import { Sid } from './serverless-api';
+
+export type LogsConfig = ClientConfig & {
+  serviceSid: Sid;
+  environment: string | Sid;
+  tail: boolean;
+  limit?: number;
+  filterByFunction?: string | Sid;
+};

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -1,9 +1,9 @@
 /** @module @twilio-labs/serverless-api */
 
-import { ClientConfig } from './client';
 import { Sid } from './serverless-api';
+import { GotClient } from './generic';
 
-export type LogsConfig = ClientConfig & {
+export type LogsConfig = {
   serviceSid: Sid;
   environment: string | Sid;
   tail: boolean;

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -1,7 +1,6 @@
 /** @module @twilio-labs/serverless-api */
 
 import { Sid } from './serverless-api';
-import { GotClient } from './generic';
 
 export type LogsConfig = {
   serviceSid: Sid;

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -9,3 +9,11 @@ export type LogsConfig = {
   limit?: number;
   filterByFunction?: string | Sid;
 };
+
+export type LogFilters = {
+  pageSize?: number;
+  functionSid?: Sid;
+  startDate?: string | Date;
+  endDate?: string | Date;
+  pageToken?: string;
+};


### PR DESCRIPTION
Initial attempt at turning polling for logs into a stream.

There are some bits missing, like passing through some of the filters in the `LogsConfig`. I can add them, I just wanted someone else to take a look at this and make sure I'm on the right track!

## Basic usage

The following will initialise a serverless API client and get a stream of the logs. It will then log every time there are new logs returned from the stream.

```javascript
const ServerlessAPI = require("@twilio-labs/serverless-api").default;
client = new ServerlessAPI({ accountSid: process.env.TWILIO_ACCOUNT_SID, authToken: process.env.TWILIO_AUTH_TOKEN});
let stream = await client.getLogsStream({ serviceSid: SERVICE_SID, environment: ENVIRONMENT_SID, tail: true })
stream.on('data', json => {
  const log = JSON.parse(json);
  console.log(`[${log.level}][${log.date_created}]: ${log.message}`);
});
```

Let me know what you think. Companion PR for `twilio-run` coming soon too.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
