### PR TITLE
chore(deps): remove deprecated @types/form-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,10 +61,9 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@types/form-data": "^2.5.0",
     "@types/mime-types": "^2.1.0",
-    "@types/recursive-readdir": "^2.2.0",
     "@types/node": "^13.13.4",
+    "@types/recursive-readdir": "^2.2.0",
     "debug": "^4.1.1",
     "fast-redact": "^1.5.0",
     "file-type": "^14.2.0",


### PR DESCRIPTION
<!-- Describe your Pull Request -->
The types for this come with the form-data package by now. So this can be removed. it's also causing a warning when people install the CLI plugin.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
