### PR TITLE
docs: Correct `require` statement in first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install @twilio-labs/serverless-api
 If you want to deploy a local project you can do this using:
 
 ```js
-const TwilioServerlessApiClient = require('@twilio-labs/serverless-api');
+const { TwilioServerlessApiClient } = require('@twilio-labs/serverless-api');
 
 const client = new TwilioServerlessApiClient({
   accountSid: '...',


### PR DESCRIPTION
Use destructuring to import `TwilioServerlessApiClient` in the first example. Without that the following error is thrown: 

```
const client = new TwilioServerlessApiClient({
               ^
TypeError: TwilioServerlessApiClient is not a constructor
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
