### PR TITLE
fix(activate): activating with environment variables

### DIFF
--- a/examples/activate.js
+++ b/examples/activate.js
@@ -1,3 +1,7 @@
+// This can be run after examples/deploy.js you just need the service Sid.
+// Run this example with:
+// node deploy/activate.js SERVICE_SID
+
 const { TwilioServerlessApiClient } = require('../dist');
 const serviceSid = process.argv[2];
 async function run() {
@@ -10,10 +14,13 @@ async function run() {
   console.log('Activating');
   const result = await client.activateBuild({
     ...config,
-    env: {},
+    env: {
+      HELLO: 'hello',
+      WORLD: 'world',
+    },
     serviceSid,
     sourceEnvironment: 'test',
-    targetEnvironment: 'stage3',
+    targetEnvironment: 'stage',
     createEnvironment: true,
   });
   console.log('Done Activating');

--- a/examples/activate.js
+++ b/examples/activate.js
@@ -1,0 +1,23 @@
+const { TwilioServerlessApiClient } = require('../dist');
+const serviceSid = process.argv[2];
+async function run() {
+  const config = {
+    accountSid: process.env.TWILIO_ACCOUNT_SID,
+    authToken: process.env.TWILIO_AUTH_TOKEN,
+  };
+
+  const client = new TwilioServerlessApiClient(config);
+  console.log('Activating');
+  const result = await client.activateBuild({
+    ...config,
+    env: {},
+    serviceSid,
+    sourceEnvironment: 'test',
+    targetEnvironment: 'stage3',
+    createEnvironment: true,
+  });
+  console.log('Done Activating');
+  console.dir(result);
+}
+
+run().catch(console.error);

--- a/src/client.ts
+++ b/src/client.ts
@@ -318,6 +318,7 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
         targetEnvironment,
         serviceSid,
         sourceEnvironment,
+        env,
       } = activateConfig;
 
       if (!buildSid && !sourceEnvironment) {
@@ -371,6 +372,12 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
       if (!buildSid) {
         throw new Error('Could not determine build SID');
       }
+
+      this.emit('status-update', {
+        status: DeployStatus.SETTING_VARIABLES,
+        message: 'Setting environment variables',
+      });
+      await setEnvironmentVariables(env, targetEnvironment, serviceSid, this);
 
       const { domain_name } = await getEnvironment(
         targetEnvironment,

--- a/src/types/activate.ts
+++ b/src/types/activate.ts
@@ -2,6 +2,7 @@
 
 import { ClientConfig } from './client';
 import { Sid } from './serverless-api';
+import { EnvironmentVariables } from './generic';
 
 export type ActivateConfig = ClientConfig & {
   force?: boolean;
@@ -10,6 +11,7 @@ export type ActivateConfig = ClientConfig & {
   buildSid?: Sid;
   targetEnvironment: string | Sid;
   sourceEnvironment?: string | Sid;
+  env: EnvironmentVariables;
 };
 
 export type ActivateResult = {


### PR DESCRIPTION
Previously activating a build would not set any env vars, this fixes that.
https://github.com/twilio-labs/twilio-run/issues/109

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
