### PR TITLE
fix(deploy): stop creating environments with domain suffix 'undefined'

### DIFF
--- a/src/__tests__/api/environments.test.ts
+++ b/src/__tests__/api/environments.test.ts
@@ -1,0 +1,71 @@
+import { createEnvironmentFromSuffix } from '../../api/environments';
+import { Mock, EqualMatchingInjectorConfig, Times } from 'moq.ts';
+import { TwilioServerlessApiClient } from '../..';
+import { Response } from 'got/dist/source';
+
+describe('createEnvironmentFromSuffix', () => {
+  test('makes a POST request to the environments API with the domainSuffix', async () => {
+    const domainSuffix = 'test';
+    const serviceSid = 'ZS123';
+    const requestMethod = 'post';
+    const path = `Services/${serviceSid}/Environments`;
+    const requestData = {
+      form: {
+        UniqueName: 'test-environment',
+        FriendlyName: 'test-environment Environment (Created by CLI)',
+        DomainSuffix: domainSuffix,
+      },
+    };
+    const mockClient = new Mock<TwilioServerlessApiClient>({
+      injectorConfig: new EqualMatchingInjectorConfig(),
+    });
+    const mockResponse = new Mock<Response>();
+    mockResponse.setup((instance) => instance.body).returns({});
+    mockClient
+      .setup((instance) => instance.request(requestMethod, path, requestData))
+      .returns(Promise.resolve(mockResponse.object()));
+
+    await createEnvironmentFromSuffix(
+      domainSuffix,
+      serviceSid,
+      mockClient.object()
+    );
+
+    mockClient.verify(
+      (instance) => instance.request(requestMethod, path, requestData),
+      Times.Once()
+    );
+  });
+
+  test('makes a POST request to the environments API without the domainSuffix', async () => {
+    const domainSuffix = '';
+    const serviceSid = 'ZS123';
+    const requestMethod = 'post';
+    const path = `Services/${serviceSid}/Environments`;
+    const requestData = {
+      form: {
+        UniqueName: 'production',
+        FriendlyName: 'production Environment (Created by CLI)',
+      },
+    };
+    const mockClient = new Mock<TwilioServerlessApiClient>({
+      injectorConfig: new EqualMatchingInjectorConfig(),
+    });
+    const mockResponse = new Mock<Response>();
+    mockResponse.setup((instance) => instance.body).returns({});
+    mockClient
+      .setup((instance) => instance.request(requestMethod, path, requestData))
+      .returns(Promise.resolve(mockResponse.object()));
+
+    await createEnvironmentFromSuffix(
+      domainSuffix,
+      serviceSid,
+      mockClient.object()
+    );
+
+    mockClient.verify(
+      (instance) => instance.request(requestMethod, path, requestData),
+      Times.Once()
+    );
+  });
+});

--- a/src/api/environments.ts
+++ b/src/api/environments.ts
@@ -1,7 +1,7 @@
 /** @module @twilio-labs/serverless-api/dist/api */
 
 import debug from 'debug';
-import { EnvironmentList, EnvironmentResource, GotClient, Sid } from '../types';
+import { EnvironmentList, EnvironmentResource, Sid } from '../types';
 import { getPaginatedResource } from './utils/pagination';
 import { ClientApiError } from '../utils/error';
 import { TwilioServerlessApiClient } from '../client';

--- a/src/api/environments.ts
+++ b/src/api/environments.ts
@@ -65,17 +65,18 @@ export async function createEnvironmentFromSuffix(
   client: TwilioServerlessApiClient
 ): Promise<EnvironmentResource> {
   const uniqueName = getUniqueNameFromSuffix(domainSuffix);
+  const form: { [key: string]: string } = {
+    UniqueName: uniqueName,
+    // this property currently doesn't exist but for the future lets set it
+    FriendlyName: `${uniqueName} Environment (Created by CLI)`,
+  };
+  if (domainSuffix !== '') {
+    form.DomainSuffix = domainSuffix;
+  }
   const resp = await client.request(
     'post',
     `Services/${serviceSid}/Environments`,
-    {
-      form: {
-        UniqueName: uniqueName,
-        DomainSuffix: domainSuffix || undefined,
-        // this property currently doesn't exist but for the future lets set it
-        FriendlyName: `${uniqueName} Environment (Created by CLI)`,
-      },
-    }
+    { form }
   );
   return (resp.body as unknown) as EnvironmentResource;
 }


### PR DESCRIPTION
According to https://github.com/twilio-labs/plugin-serverless/issues/35 deploying using the `--production` flag lead to a URL with 'undefined' in the domain. I think this used to work, but there was either a change in the behaviour of `got` around sending `undefined` values in form data between version 9.6.0 and the current version 11.0.1, or the Serverless API changed. I started thinking it was the API, but I'm closer to believing it was `got` now.

Anyway, not sending the `DomainSuffix` key when it is an empty string instead of sending `undefined` should now work.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
