### PR TITLE
feat(client): adds username and password support

### DIFF
--- a/examples/activate.js
+++ b/examples/activate.js
@@ -6,8 +6,8 @@ const { TwilioServerlessApiClient } = require('../dist');
 const serviceSid = process.argv[2];
 async function run() {
   const config = {
-    accountSid: process.env.TWILIO_ACCOUNT_SID,
-    authToken: process.env.TWILIO_AUTH_TOKEN,
+    username: process.env.TWILIO_ACCOUNT_SID,
+    password: process.env.TWILIO_AUTH_TOKEN,
   };
 
   const client = new TwilioServerlessApiClient(config);

--- a/examples/deploy.js
+++ b/examples/deploy.js
@@ -1,8 +1,8 @@
 const { TwilioServerlessApiClient } = require('../dist');
 async function run() {
   const config = {
-    accountSid: process.env.TWILIO_ACCOUNT_SID,
-    authToken: process.env.TWILIO_AUTH_TOKEN,
+    username: process.env.TWILIO_ACCOUNT_SID,
+    password: process.env.TWILIO_AUTH_TOKEN,
   };
 
   const client = new TwilioServerlessApiClient(config);

--- a/src/__fixtures__/base-fixtures.ts
+++ b/src/__fixtures__/base-fixtures.ts
@@ -1,4 +1,15 @@
-export const DEFAULT_TEST_CLIENT_CONFIG = {
+import {
+  ClientConfig,
+  AccountSidConfig,
+  UsernameConfig,
+} from '../types/client';
+
+export const DEFAULT_TEST_CLIENT_CONFIG: AccountSidConfig = {
   accountSid: 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
   authToken: '<SECRET>',
+};
+
+export const DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD: UsernameConfig = {
+  username: 'ACyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy',
+  password: '<PASSWORD>',
 };

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,5 +1,8 @@
 import { createGotClient } from '../client';
-import { DEFAULT_TEST_CLIENT_CONFIG } from '../__fixtures__/base-fixtures';
+import {
+  DEFAULT_TEST_CLIENT_CONFIG,
+  DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD,
+} from '../__fixtures__/base-fixtures';
 
 describe('createGotClient', () => {
   test('works with default configuration', () => {
@@ -13,6 +16,20 @@ describe('createGotClient', () => {
     );
     expect((options as any).password).toBe(
       DEFAULT_TEST_CLIENT_CONFIG.authToken
+    );
+  });
+
+  test('works with username and password', () => {
+    const config = DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD;
+    const client = createGotClient(config);
+    const options = client.defaults.options;
+    expect(options.prefixUrl).toBe('https://serverless.twilio.com/v1/');
+    expect(options.responseType).toBe('json');
+    expect((options as any).username).toBe(
+      DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD.username
+    );
+    expect((options as any).password).toBe(
+      DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD.password
     );
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -60,15 +60,26 @@ import {
   Response,
 } from 'got/dist/source';
 import pLimit, { Limit } from 'p-limit';
+import { deprecate } from 'util';
 
 const log = debug('twilio-serverless-api:client');
 
 export function createGotClient(config: ClientConfig): GotClient {
+  let username, password;
+  if ('accountSid' in config) {
+    username = config.accountSid;
+    password = config.authToken;
+    deprecate(() => {},
+    '`accountSid` and `authToken` client config is deprecated, please use `username` and `password` instead.')();
+  } else {
+    username = config.username;
+    password = config.password;
+  }
   const client = got.extend({
     prefixUrl: getApiUrl(config),
     responseType: 'json',
-    username: config.accountSid,
-    password: config.authToken,
+    username: username,
+    password: password,
     headers: {
       'User-Agent': 'twilio-serverless-api',
     },

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,17 +1,6 @@
 /** @module @twilio-labs/serverless-api */
 
-/**
- * Config to set up a API request client
- */
-export type ClientConfig = {
-  /**
-   * Twilio AccountSID or API Key
-   */
-  accountSid: string;
-  /**
-   * Twilio Auth Token or API Secret
-   */
-  authToken: string;
+type BaseClientConfig = {
   /**
    * Twilio Region
    */
@@ -29,3 +18,30 @@ export type ClientConfig = {
    */
   retryLimit?: number;
 };
+
+export type AccountSidConfig = BaseClientConfig & {
+  /**
+   * Twilio AccountSID or API Key
+   */
+  accountSid: string;
+  /**
+   * Twilio Auth Token or API Secret
+   */
+  authToken: string;
+};
+
+export type UsernameConfig = BaseClientConfig & {
+  /**
+   * Twilio AccountSID or API Key
+   */
+  username: string;
+  /**
+   * Twilio Auth Token or API Secret
+   */
+  password: string;
+};
+
+/**
+ * Config to set up a API request client
+ */
+export type ClientConfig = AccountSidConfig | UsernameConfig;

--- a/src/utils/__tests__/error.test.ts
+++ b/src/utils/__tests__/error.test.ts
@@ -2,12 +2,11 @@ import nock from 'nock';
 import util from 'util';
 import { createGotClient } from '../../client';
 import { ClientApiError } from '../error';
-import { ClientConfig } from '../../types';
 import { DEFAULT_TEST_CLIENT_CONFIG } from '../../__fixtures__/base-fixtures';
 
 describe('ClientApiError', () => {
   let apiNock = nock('https://serverless.twilio.com');
-  let config: ClientConfig = DEFAULT_TEST_CLIENT_CONFIG;
+  let config = DEFAULT_TEST_CLIENT_CONFIG;
   let apiClient = createGotClient(config);
 
   beforeEach(() => {


### PR DESCRIPTION
This deprecates `accountSid` and `authToken`.

Fixes #41.

This can be completely removed once we release a new major version.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
