### PR TITLE
fix(logs): change caching of seen log entries

### DIFF
--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -9,6 +9,7 @@ export type LogsConfig = {
   limit?: number;
   filterByFunction?: string | Sid;
   pollingFrequency?: number;
+  logCacheSize?: number;
 };
 
 export type LogFilters = {


### PR DESCRIPTION
There is an edge case where the logs endpoint will return no new logs followed by logs that had
already been seen. This results in duplicate logging of the logs on our side. This changes the
implementation to maintain a certain sized queue of cached entries. This PR is backfilling the fix
that is shipping in the next major version.

re twilio-labs/serverless-toolkit#192

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
