### PR TITLE
feat(runtime): adds runtime parameter to config

### DIFF
--- a/examples/deploy.js
+++ b/examples/deploy.js
@@ -10,6 +10,7 @@ async function run() {
   const result = await client.deployProject({
     ...config,
     overrideExistingService: true,
+    runtime: 'node12',
     env: {
       HELLO: 'ahoy',
       WORLD: 'welt',

--- a/src/api/builds.ts
+++ b/src/api/builds.ts
@@ -88,7 +88,7 @@ export async function triggerBuild(
   serviceSid: string,
   client: TwilioServerlessApiClient
 ): Promise<BuildResource> {
-  const { functionVersions, dependencies, assetVersions } = config;
+  const { functionVersions, dependencies, assetVersions, runtime } = config;
   try {
     const body: ParsedUrlQueryInput = {};
 
@@ -103,6 +103,10 @@ export async function triggerBuild(
 
     if (Array.isArray(assetVersions) && assetVersions.length > 0) {
       body.AssetVersions = assetVersions;
+    }
+
+    if (runtime) {
+      body.Runtime = runtime;
     }
 
     const resp = await client.request('post', `Services/${serviceSid}/Builds`, {

--- a/src/client.ts
+++ b/src/client.ts
@@ -438,7 +438,7 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
         ...deployConfig,
       };
 
-      const { functions, assets } = config;
+      const { functions, assets, runtime } = config;
 
       let serviceSid = config.serviceSid;
       if (!serviceSid) {
@@ -541,7 +541,7 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
       });
       const dependencies = getDependencies(config.pkgJson);
       const build = await triggerBuild(
-        { functionVersions, dependencies, assetVersions },
+        { functionVersions, dependencies, assetVersions, runtime },
         serviceSid,
         this
       );
@@ -575,6 +575,7 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
         domain,
         functionResources,
         assetResources,
+        runtime: build.runtime,
       };
     } catch (err) {
       convertApiErrorsAndThrow(err);

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -43,6 +43,10 @@ type DeployProjectConfigBase = {
    * If no `serviceSid` is specified but a service with `serviceName` is found, it will deploy to that one.
    */
   overrideExistingService?: boolean;
+  /**
+   * Version of Node.js to deploy with in Twilio Runtime. Can be "node10" or "node12"
+   */
+  runtime?: string;
 };
 
 /**
@@ -106,6 +110,7 @@ export type DeployResult = {
   domain: string;
   functionResources: FunctionResource[];
   assetResources: AssetResource[];
+  runtime: string;
 };
 
 export type StatusUpdate = {

--- a/src/types/serverless-api.ts
+++ b/src/types/serverless-api.ts
@@ -101,6 +101,7 @@ export interface BuildResource extends UpdateableResourceBase {
   status: BuildStatus;
   function_versions: FunctionVersion[];
   asset_versions: AssetVersion[];
+  runtime: string;
 }
 
 export interface BuildList extends BaseList<'builds'> {
@@ -122,6 +123,7 @@ export type BuildConfig = {
   dependencies?: Dependency[];
   functionVersions?: Sid[];
   assetVersions?: Sid[];
+  runtime?: string;
 };
 
 export interface LogApiResource extends ResourceBase {


### PR DESCRIPTION
Backporting this for v4.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
