### PR TITLE
fix(pagination): corrects overwrite of prefixUrl in pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "fast-redact": "^1.5.0",
     "file-type": "^14.2.0",
     "form-data": "^2.5.0",
-    "got": "^11.0.1",
+    "got": "^11.8.2",
     "mime-types": "^2.1.22",
     "p-limit": "^2.3.0",
     "recursive-readdir": "^2.2.2",

--- a/src/api/utils/__tests__/pagination.test.ts
+++ b/src/api/utils/__tests__/pagination.test.ts
@@ -92,6 +92,10 @@ describe('pagination', () => {
     );
 
     expect(client.request).toHaveBeenCalledTimes(5);
+    expect(client.request).toHaveBeenCalledWith('get', '/Services', {
+      prefixUrl: '',
+      responseType: 'json',
+    });
     expect(results.length).toBe(5);
     expect(results[0].sid).toBe('ZS0');
     expect(results[1].sid).toBe('ZS1');

--- a/src/api/utils/pagination.ts
+++ b/src/api/utils/pagination.ts
@@ -24,7 +24,7 @@ export async function getPaginatedResource<
   do {
     try {
       if (nextPageUrl.startsWith('http')) {
-        opts.prefixUrl = undefined;
+        opts.prefixUrl = '';
       }
       const resp = await client.request('get', nextPageUrl, opts);
       const body = resp.body as TList;


### PR DESCRIPTION
`got` changed behaviour around setting a `prefixUrl` to `undefined` leading to our pagination requests 404ing because the request URL looked like `https://serverless.twilio.com/v1/https://serverless.twilio.com/v1/PATH`.

Setting `prefixUrl` to empty string solves the issue.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
